### PR TITLE
Parse ~ as home directory

### DIFF
--- a/src/_utils.js
+++ b/src/_utils.js
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import { GoogleAuth } from "google-auth-library";
 import { findUp } from "find-up";
 import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
 
 export const load_config = async (configFile = "config.json") => {
   try {
@@ -19,17 +20,18 @@ export const fatal_error = (message) => {
 };
 
 export const success = (message) => {
-  console.log(chalk.green(message))
-}
+  console.log(chalk.green(message));
+};
 
-export const get_auth = (auth, scopes) => {
-  if (!existsSync(auth)) {
+export const get_auth = (path, scopes) => {
+  const file = path.startsWith("~") ? path.replace("~", homedir()) : path;
+  if (!existsSync(file)) {
     fatal_error(`
-  Could not open service account credentials at ${auth}.
+  Could not open service account credentials at ${file}.
   Reconfigure fetch.sheets.auth in config.json or download the credentials file.
   `);
   }
 
-  const authObject = new GoogleAuth({ keyFile: auth, scopes });
-  return authObject
-}
+  const authObject = new GoogleAuth({ keyFile: file, scopes });
+  return authObject;
+};

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -32,6 +32,5 @@ export const get_auth = (path, scopes) => {
   `);
   }
 
-  const authObject = new GoogleAuth({ keyFile: file, scopes });
-  return authObject;
+  return new GoogleAuth({ keyFile: file, scopes });
 };


### PR DESCRIPTION
#### What's this PR do?

Bash (and presumably other shells) performs [tilde expansion](https://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html) to the home directory. Node does not do this by default when parsing paths. This PR performs the basic tilde expansion when retrieving the Google authentication file.

#### Why are we doing this? How does it help us?

See <https://github.com/MichiganDaily/sourdough/issues/22#issuecomment-1200014670>

#### How should this be manually tested?

1. Clone this repository.
2. Install dependencies by running `yarn install`.
3. Add a test configuration file to try to fetch something. 
4. Place the authentication file at the root of the repository. Fetch the file.
5. Place the authentication file in the home directory. Fetch the file.

#### Are there any smells or added technical debt to note?

No.

#### What are relevant issues or links?

<https://github.com/MichiganDaily/sourdough/issues/22#issuecomment-1200014670>

#### Have you done the following, if applicable:

* [x] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
