### PR TITLE
Support fetching JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 > Everything and the kitchen sink
 
-A collection of helper scripts that are used across The Michigan Daily's
-projects.
+A collection of helper scripts that are used across The Michigan Daily's projects.
 
 ## Installation
 
@@ -16,8 +15,8 @@ It's really easy, just run
 ```sh
 sink gsheet  # fetch Google Sheets
 sink gdoc    # fetch Google Docs
-sink fetch # fetch Google Sheets and Docs
+sink json    # fetch JSON files
+sink fetch   # fetch everything
 ```
 
-Like before, you still need a `config.json` (usually comes with the template
-that is using `sink`) and an `auth.json` (usually comes with your MOE).
+Like before, you still need a `config.json` (usually comes with the template that is using `sink`) and an `auth.json` (usually comes with your MOE).

--- a/config.example.json
+++ b/config.example.json
@@ -1,13 +1,21 @@
 {
   "fetch": [
     {
+      "type": "doc",
       "id": "",
       "output": "",
       "auth": "~/.daily-google-services.json"
     },
     {
+      "type": "sheet",
       "id": "",
       "sheetId": "0",
+      "output": "",
+      "auth": "~/.daily-google-services.json"
+    },
+    {
+      "type": "json",
+      "id": "",
       "output": "",
       "auth": "~/.daily-google-services.json"
     }

--- a/config.example.json
+++ b/config.example.json
@@ -3,13 +3,13 @@
     {
       "id": "",
       "output": "",
-      "auth": "./auth.json"
+      "auth": "~/.daily-google-services.json"
     },
     {
       "id": "",
       "sheetId": "0",
       "output": "",
-      "auth": "./auth.json"
+      "auth": "~/.daily-google-services.json"
     }
   ]
 }

--- a/src/sink-fetch.js
+++ b/src/sink-fetch.js
@@ -4,14 +4,21 @@ import { program } from "commander/esm.mjs";
 
 import { fetchDoc } from "./sink-gdoc.js";
 import { fetchSheet } from "./sink-gsheet.js";
+import { fetchJson } from "./sink-json.js";
 import { load_config } from "./_utils.js";
 
 const main = async (opts) => {
+  const typeToFunction = {
+    doc: fetchDoc,
+    sheet: fetchSheet,
+    json: fetchJson,
+  };
+
   const { config } = await load_config(opts.config);
   config.fetch
     .filter((d) => d.id.length && d.output.length)
     .forEach((file) => {
-      const func = file.sheetId == null ? fetchDoc : fetchSheet;
+      const func = typeToFunction(file.type);
       func(file);
     });
 };

--- a/src/sink-gdoc.js
+++ b/src/sink-gdoc.js
@@ -125,7 +125,7 @@ export const fetchDoc = async ({ id, output, auth }) => {
 const main = async (opts) => {
   const { config } = await load_config(opts.config);
   const files = config.fetch.filter(
-    (d) => d.sheetId == null && d.id.length && d.output.length
+    (d) => d.type === "doc" && d.id.length && d.output.length
   );
   files.forEach(fetchDoc);
 };

--- a/src/sink-gsheet.js
+++ b/src/sink-gsheet.js
@@ -52,7 +52,7 @@ export const fetchSheet = async ({ id, sheetId, output, auth }) => {
 async function main(opts) {
   const { config } = await load_config(opts.config);
   const files = config.fetch.filter(
-    (d) => d.sheetId !== undefined && d.id.length && d.output.length
+    (d) => d.type === "sheet" && d.id.length && d.output.length
   );
   files.forEach(fetchSheet);
 }

--- a/src/sink-gsheet.js
+++ b/src/sink-gsheet.js
@@ -52,7 +52,8 @@ export const fetchSheet = async ({ id, sheetId, output, auth }) => {
 async function main(opts) {
   const { config } = await load_config(opts.config);
   const files = config.fetch.filter(
-    (d) => d.type === "sheet" && d.id.length && d.output.length
+    (d) =>
+      d.type === "sheet" && d.id.length && d.output.length && d.sheetId.length
   );
   files.forEach(fetchSheet);
 }

--- a/src/sink-json.js
+++ b/src/sink-json.js
@@ -1,0 +1,41 @@
+import { fileURLToPath } from "node:url";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+
+import { program } from "commander/esm.mjs";
+import { drive } from "@googleapis/drive";
+
+import { load_config, success, get_auth } from "./_utils";
+
+export const fetchJson = async ({ id, output, auth }) => {
+  const scopes = ["https://www.googleapis.com/auth/drive"];
+  const authObject = get_auth(auth, scopes);
+
+  const gdrive = drive({ version: "v3", auth: authObject });
+
+  const file = await gdrive.files.export({ fileId: id, mimeType: "text/json" });
+  console.log(file);
+
+  // const dir = output.substring(0, output.lastIndexOf("/"));
+  // !existsSync(dir.length > 0 ? dir : ".") &&
+  //   mkdirSync(dir, { recursive: true });
+  // writeFileSync(output, JSON.stringify(json));
+  // success(`Wrote output to ${output}`);
+};
+
+const main = async (opts) => {
+  const { config } = await load_config(opts.config);
+  const files = config.fetch.filter(
+    (d) => d.sheetId == null && d.id.length && d.output.length
+  );
+  files.forEach(fetchJson);
+};
+
+const self = fileURLToPath(import.meta.url);
+if (process.argv[1] === self) {
+  program
+    .version("1.3.0")
+    .option("-c, --config <path>", "path to config file")
+    .parse();
+
+  main(program.opts());
+}

--- a/src/sink-json.js
+++ b/src/sink-json.js
@@ -24,7 +24,7 @@ export const fetchJson = async ({ id, output, auth }) => {
 const main = async (opts) => {
   const { config } = await load_config(opts.config);
   const files = config.fetch.filter(
-    (d) => d.sheetId == null && d.id.length && d.output.length
+    (d) => d.type === "json" && d.id.length && d.output.length
   );
   files.forEach(fetchJson);
 };

--- a/src/sink-json.js
+++ b/src/sink-json.js
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { program } from "commander/esm.mjs";
 import { drive } from "@googleapis/drive";
 
-import { load_config, success, get_auth } from "./_utils";
+import { load_config, success, get_auth } from "./_utils.js";
 
 export const fetchJson = async ({ id, output, auth }) => {
   const scopes = ["https://www.googleapis.com/auth/drive"];
@@ -12,14 +12,13 @@ export const fetchJson = async ({ id, output, auth }) => {
 
   const gdrive = drive({ version: "v3", auth: authObject });
 
-  const file = await gdrive.files.export({ fileId: id, mimeType: "text/json" });
-  console.log(file);
+  const { data } = await gdrive.files.get({ fileId: id, alt: "media" });
 
-  // const dir = output.substring(0, output.lastIndexOf("/"));
-  // !existsSync(dir.length > 0 ? dir : ".") &&
-  //   mkdirSync(dir, { recursive: true });
-  // writeFileSync(output, JSON.stringify(json));
-  // success(`Wrote output to ${output}`);
+  const dir = output.substring(0, output.lastIndexOf("/"));
+  !existsSync(dir.length > 0 ? dir : ".") &&
+    mkdirSync(dir, { recursive: true });
+  writeFileSync(output, JSON.stringify(data));
+  success(`Wrote output to ${output}`);
 };
 
 const main = async (opts) => {

--- a/src/sink.js
+++ b/src/sink.js
@@ -8,6 +8,7 @@ program
   .description("Utility scripts")
   .command("gdoc", "fetch ArchieML Google Doc into JSON file")
   .command("gsheet", "fetch Google Sheet into CSV file")
+  .command("json", "fetch JSON files from Google Drive")
   .command("fetch", "fetch all Google Docs and Sheets");
 
 program.parse(process.argv);


### PR DESCRIPTION
#### What's this PR do?

See title. This means that we'll now have to specify the type of the document we're fetching now with `"type": "goc" | "sheet" | "json"`. We used to get away with looking if a `sheetId` property existed but to Google Drive, importing a JSON file and a Document only requires an ID.

#### Are there any relevant screenshots?

#### Why are we doing this? How does it help us?

There are cases when it'd be beneficial to store JSON files in a shared Google Drive. This allows us to fetch those files for consistency!

#### How should this be manually tested?

Try out all of the commands!

#### Are there any smells or added technical debt to note?

#### What are relevant issues or links?

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
