### PR TITLE
Jsconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Create a configuration file (i.e. `config.json`). The JSON file should have a `f
 }
 ```
 
-You can also configure sink with a Javascript file, by exporting the JSON config as the default export.
+You can also configure `sink` with a JavaScript file by exporting the JSON config as the default export.
 
 ### Specifying the output file path
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Create a configuration file (i.e. `config.json`). The JSON file should have a `f
 }
 ```
 
+You can also configure sink with a Javascript file, by exporting the JSON config as the default export.
+
 ### Specifying the output file path
 
 For each `output` property, specify a path relative to `config.json` or an absolute path. When a fetch command is run, the relevant file(s) will be written to the `output` path.

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -6,7 +6,7 @@ import { GoogleAuth } from "google-auth-library";
 import { findUp } from "find-up";
 
 const _is_js_config = (filename) => {
-  return filename.slice(-2) == "js";
+  return filename.slice(-2) === "js";
 }
 
 export const read_json_config = (path) => {

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -26,7 +26,7 @@ export const load_config = async (configFile = null) => {
   const searchFiles = configFile ? [configFile, ...defaults] : defaults
   for (const searchFile of searchFiles) {
     const path = await findUp(searchFile);
-    if (typeof path == "undefined") continue;
+    if (typeof path === "undefined") continue;
     if (_is_js_config(path)) {
       return await read_js_config(path)
     }

--- a/src/_utils.js
+++ b/src/_utils.js
@@ -5,16 +5,34 @@ import chalk from "chalk";
 import { GoogleAuth } from "google-auth-library";
 import { findUp } from "find-up";
 
+const _is_js_config = (filename) => {
+  return filename.slice(-2) == "js";
+}
+
+export const read_json_config = (path) => {
+  return { config: JSON.parse(readFileSync(path)) };
+}
+
+export const read_js_config = async (path) => {
+  const config = (await import(path)).default
+  return { config }
+}
+
 export const has_filled_props = (o) => Object.values(o).every((v) => v.length);
 
 // Search directory for configuration file
-export const load_config = async (configFile = "config.json") => {
-  try {
-    const path = await findUp(configFile);
-    return { config: JSON.parse(readFileSync(path)) };
-  } catch {
-    fatal_error("Could not load config file");
+export const load_config = async (configFile = null) => {
+  const defaults = ["sink.config.js", "sink.config.json", "config.json"];
+  const searchFiles = configFile ? [configFile, ...defaults] : defaults
+  for (const searchFile of searchFiles) {
+    const path = await findUp(searchFile);
+    if (typeof path == "undefined") continue;
+    if (_is_js_config(path)) {
+      return await read_js_config(path)
+    }
+    return read_json_config(path)
   }
+  fatal_error("Could not load config file");
 };
 
 export const write_file = (output, content) => {


### PR DESCRIPTION
#### What's this PR do?

Support `.js` configs where the default export is the JSON configuration. I also added `sink.config.json` and `sink.config.js` as possible default config filenames which take precedent before `config.json`.

#### Why are we doing this? How does it help us?

This is useful for dynamically constructing configs (e.g. if you have a spreadsheet of docs to pull from)

#### How should this be manually tested?

Create a `sink.config.js` with these contents:
```js
const config = {/* put your config.json in this object */}
export default config
```

Verify that all of the functions work the same.

#### Are there any smells or added technical debt to note?

JSON configs can also probably be handled with dynamic imports, but right now we just `readFileSync` (which is fine)

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
