### PR TITLE
Configure OAuth workflow

### DIFF
--- a/src/sink-auth.js
+++ b/src/sink-auth.js
@@ -1,0 +1,85 @@
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import { readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+
+import { program } from "commander";
+import { OAuth2Client } from "google-auth-library";
+import chalk from "chalk";
+import { success } from "./_utils.js";
+
+const self = fileURLToPath(import.meta.url);
+
+const main = async () => {
+  const authPath = "~/.sink-google-auth-oauth-client.json";
+  const absoluteAuthPath = authPath.startsWith("~") ? authPath.replace("~", homedir()) : authPath;
+  const auth = JSON.parse(readFileSync(absoluteAuthPath).toString());
+
+  const client = new OAuth2Client(
+    auth.web.client_id,
+    auth.web.client_secret,
+    auth.web.redirect_uris[0]
+  );
+
+  const authorizationUrl = client.generateAuthUrl({
+    access_type: "offline",
+    scope: "https://www.googleapis.com/auth/drive.readonly"
+  });
+
+  console.log(
+    `Start the OAuth workflow at ${chalk.yellow(authorizationUrl)}.`
+  );
+
+  console.log(
+    "Note that you are expected to see an error screen after getting redirected to a localhost URL."
+  )
+
+  let server;
+  const sockets = new Set();
+
+  const token = await new Promise((resolve) => {
+    server = createServer(async (req) => {
+      const queryParams = new URL(req.url, "http://localhost:3000").searchParams;
+      const code = queryParams.get("code");
+      const { tokens } = await client.getToken(code);
+      resolve(tokens);
+    });
+
+    server.listen(3000);
+
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+
+      server.once("close", () => {
+        sockets.delete(socket);
+      })
+    })
+  });
+
+  for (const socket of sockets) {
+    socket.destroy();
+    sockets.delete(socket);
+  }
+
+  server.close();
+
+  const tokenPath = `${homedir()}/.sink-google-auth-oauth-token.json`
+  writeFileSync(
+    tokenPath, 
+    JSON.stringify({
+      type: "oauth",
+      clientPath: absoluteAuthPath,
+      ...token
+    })
+  );
+
+  success(`A Google OAuth token has been generated at ${tokenPath}.`);
+}
+
+if (process.argv[1] === self) {
+  program
+    .version("2.7.3")
+    .parse();
+
+  main();
+}

--- a/src/sink.js
+++ b/src/sink.js
@@ -11,6 +11,7 @@ program
   .command("json", "fetch JSON files from Google Drive")
   .command("text", "fetch text files from Google Drive")
   .command("fetch", "fetch all Google Docs and Sheets")
-  .command("deploy", "deploy a build directory to AWS S3");
+  .command("deploy", "deploy a build directory to AWS S3")
+  .command("auth", "authenticate with Google OAuth");
 
 program.parse(process.argv);


### PR DESCRIPTION
#### What's this PR do?

#### Are there any relevant screenshots?

#### Why are we doing this? How does it help us?

#### How should this be manually tested?

- Create an OAuth client in Google Cloud Platform with readonly permissions for Google Drive. Ensure that the Google Drive API is enabled in the API Library. The OAuth client should have a **Web** application type, use http://localhost:3000 as the authorized JavaScript origin, and use http://localhost:3000/redirect as the redirect URI. Download the JSON client file and save it to `~./sink-google-auth-oauth-client.json`. Currently, this is the only supported file location though we can allow the user to specify where they want to store their client configuration file.
- Run `yarn sink auth` to generate a `~/.sink-google-auth-oauth-token.json` file.
- In your configuration, set your `auth` property to the above path to fetch with the OAuth token.

#### Are there any smells or added technical debt to note?

#### What are relevant issues or links?

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
