### PR TITLE
Check contents not undefined

### DIFF
--- a/src/sink-deploy.js
+++ b/src/sink-deploy.js
@@ -200,7 +200,7 @@ const main = async ([platform], opts) => {
       }
     };
 
-    if (Object.hasOwn(response, "Contents")) {
+    if (Object.hasOwn(response, "Contents") && response.Contents) {
       const content = response.Contents.filter(
         (d) => !d.Key.endsWith("/")
       ).sort((a, b) => depth(a.Key) - depth(b.Key));


### PR DESCRIPTION
#### What's this PR do?

This fixes a breaking bug with sink where deploying to a new folder results in failure. This is due to our `response.Contents` check, which checks that `Contents` is a field in `response` but does not actually check if `Contents` is defined or not, resulting in failure when we try to index into `Contents`. This PR adds a quick check to that to ensure that we can start deploying specials sites again.

#### Are there any relevant screenshots?

#### Why are we doing this? How does it help us?

#### How should this be manually tested?

#### Are there any smells or added technical debt to note?

#### What are relevant issues or links?

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
